### PR TITLE
corrected toView argument ordering per service function / docs

### DIFF
--- a/src/df.js
+++ b/src/df.js
@@ -6,7 +6,7 @@ export class DfValueConverter {
     this.service = i18n;
   }
 
-  toView(value, locale, formatOptions, dateFormat) {
+  toView(value, formatOptions, locale, dateFormat) {
     var df = dateFormat || this.service.df(formatOptions, locale || this.service.getLocale());
 
     return df.format(value);

--- a/src/nf.js
+++ b/src/nf.js
@@ -6,7 +6,7 @@ export class NfValueConverter {
     this.service = i18n;
   }
 
-  toView(value, locale, formatOptions, numberFormat) {
+  toView(value, formatOptions, locale, numberFormat) {
     var nf = numberFormat || this.service.nf(formatOptions, locale || this.service.getLocale());
 
     return nf.format(value);

--- a/test/unit/dfvalueconverter.spec.js
+++ b/test/unit/dfvalueconverter.spec.js
@@ -1,0 +1,37 @@
+import {I18N} from '../../src/i18n';
+import {DfValueConverter} from '../../src/df'
+
+describe('dfvalueconverter tests', () => {
+
+  var sut, dfvc;
+
+  beforeEach(() => {
+    sut = new I18N();
+     dfvc = new DfValueConverter(sut);
+  });
+
+  it('should display only the date in the setup locale format by default', () => {
+    var testDate = new Date(2000, 0, 1, 0,0,1);
+
+    expect(dfvc.toView(testDate)).toEqual('1/1/2000');
+  });
+
+  it('should display date in the previously modified locale', (done) => {
+    sut.setLocale('de').then( () => {
+      var testDate = new Date(2000, 0, 1, 0,0,1);
+      expect(dfvc.toView(testDate)).toEqual('1.1.2000');
+      done();
+    });
+  });
+
+  it('should display datetime',() => {
+    var options = {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      hour12: false
+    };
+    var testDate = new Date(2000, 0, 1, 0,0,1);
+    expect(dfvc.toView(testDate,options,'de')).toEqual('01.01.2000, 00:00:01');
+  });
+
+});

--- a/test/unit/nfvalueconverter.spec.js
+++ b/test/unit/nfvalueconverter.spec.js
@@ -1,0 +1,30 @@
+import {I18N} from '../../src/i18n';
+import {NfValueConverter} from '../../src/nf';
+
+describe('nfvalueconverter tests', () => {
+  
+  var sut, nfvc;
+  beforeEach(function() {
+    sut = new I18N();
+    nfvc = new NfValueConverter(sut);
+  });
+
+  it('should display number in the setup locale format by default', () => {
+    var testNumber = 123456.789;
+    expect(nfvc.toView(testNumber)).toEqual('123,456.789');
+  });
+
+  it('should display number in the previously modified locale', (done) => {
+    sut.setLocale('de').then( () => {
+      var testNumber = 123456.789;
+      expect(nfvc.toView(testNumber)).toEqual('123.456,789');
+      done();
+    });
+  });
+
+  it('should display number as currency',() => {
+    var testNumber = 123456.789;
+    expect(nfvc.toView(testNumber,{ style: 'currency', currency: 'JPY' }, 'de')).toBe('123.456,789 ¥');
+  });
+
+});


### PR DESCRIPTION
There was a mismatch in the argument ordering based on the docs + the service function expectations.  Also, added unit tests for the value converters to cover these cases.   