### PR TITLE
feat(html-attributes): use html attributes to manage translations

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,9 +1,15 @@
 System.config({
-  "transpiler": "traceur",
+  "transpiler": "babel",
+  "babelOptions": {
+    "optional": [
+      "es7.decorators"
+    ]
+  },
   "paths": {
     "*": "*.js",
     "aurelia-i18next/*": "dist\\system/*.js",
-    "github:*": "jspm_packages/github/*.js"
+    "github:*": "jspm_packages/github/*.js",
+    "npm:*": "jspm_packages/npm/*.js"
   }
 });
 
@@ -11,9 +17,33 @@ System.config({
   "map": {
     "Intl.js": "github:andyearnshaw/Intl.js@0.1.4",
     "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.4.0",
-    "i18next": "github:i18next/i18next@1.8.0",
-    "traceur": "github:jmcriffey/bower-traceur@0.0.88",
-    "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88"
+    "aurelia-loader-default": "github:aurelia/loader-default@0.7.0",
+    "babel": "npm:babel-core@5.4.4",
+    "babel-runtime": "npm:babel-runtime@5.4.4",
+    "core-js": "npm:core-js@0.9.11",
+    "i18next": "github:i18next/i18next@1.9.0",
+    "text": "github:systemjs/plugin-text@0.0.2",
+    "github:aurelia/loader-default@0.7.0": {
+      "aurelia-loader": "github:aurelia/loader@0.6.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.5.0"
+    },
+    "github:aurelia/loader@0.6.0": {
+      "aurelia-html-template-element": "github:aurelia/html-template-element@0.2.0",
+      "aurelia-path": "github:aurelia/path@0.6.1",
+      "core-js": "npm:core-js@0.9.11",
+      "webcomponentsjs": "github:webcomponents/webcomponentsjs@0.6.1"
+    },
+    "github:aurelia/metadata@0.5.0": {
+      "core-js": "npm:core-js@0.9.11"
+    },
+    "github:jspm/nodelibs-process@0.1.1": {
+      "process": "npm:process@0.10.1"
+    },
+    "npm:core-js@0.9.11": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "process": "github:jspm/nodelibs-process@0.1.1",
+      "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    }
   }
 });
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,12 +14,15 @@ module.exports = function(config) {
 
     jspm: {
       // Edit this to your needs
-      loadFiles: ['src/**/*.js', 'test/unit/**/*.js']
+      loadFiles: ['test/unit/**/*.js'],
+      serveFiles : ['src/**/*.js','test/unit/fixtures/**/*']
     },
 
 
     // list of files / patterns to load in the browser
-    files: [],
+    files: [
+      {pattern: 'test/unit/fixtures/**/*.html', included: false}
+    ],
 
 
     // list of files to exclude

--- a/package.json
+++ b/package.json
@@ -50,11 +50,17 @@
     "dependencies": {
       "Intl.js": "github:andyearnshaw/Intl.js@^0.1.4",
       "aurelia-event-aggregator": "github:aurelia/event-aggregator@^0.4.0",
-      "i18next": "github:i18next/i18next@^1.8.0"
+      "i18next": "github:i18next/i18next@^1.9.0",
+      "text": "github:systemjs/plugin-text@^0.0.2"
     },
     "devDependencies": {
-      "traceur": "github:jmcriffey/bower-traceur@0.0.88",
-      "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88"
+      "aurelia-loader-default": "github:aurelia/loader-default@^0.7.0",
+      "babel": "npm:babel-core@^5.1.13",
+      "babel-runtime": "npm:babel-runtime@^5.1.13",
+      "core-js": "npm:core-js@^0.9.4"
     }
+  },
+  "dependencies": {
+    "jsdom": "^3.1.2"
   }
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -22,11 +22,14 @@ export class I18N {
       lng : 'en',
       getAsync : false,
       sendMissing : false,
+      attributes : ['t','i18n'],    //attributes that will be searched for when searching for keys the html
       fallbackLng : 'en',
       debug : false
     };
 
     i18n.init(options || defaultOptions);
+    //make sure attributes is an array in case a string was provided
+    if(i18n.options.attributes instanceof String) i18n.options.attributes = [i18n.options.attributes];
   }
 
   setLocale(locale) {
@@ -53,4 +56,85 @@ export class I18N {
   tr(key, options) {
     return this.i18next.t(key, assignObjectToKeys('', options));
   }
+
+  /**
+   * Scans an element for children that have a translation attribute and
+   * updates their innerHTML with the current translation values.
+   *
+   * If an image is encountered the translated value will be applied to the src attribute.
+   *
+   * @param el    HTMLElement to search within
+   */
+  updateTranslations(el){
+
+    var i,l;
+
+    //create a selector from the specified attributes to look for
+    //var selector = [].concat(this.i18next.options.attributes);
+    var selector = [].concat(this.i18next.options.attributes);
+    for(i = 0, l = selector.length; i < l; i++) selector[i] = "["+selector[i]+"]";
+    selector = selector.join(",");
+
+    //get the nodes
+    var nodes = el.querySelectorAll(selector);
+    for(i = 0, l = nodes.length; i < l; i++){
+      var node = nodes[i];
+      var keys;
+      //test every attribute and get the first one that has a value
+      for(var i2 = 0, l2 = this.i18next.options.attributes.length; i2 < l2; i2++){
+        keys = node.getAttribute(this.i18next.options.attributes[i2]);
+        if(keys) break;
+      }
+      //skip if nothing was found
+      if(!keys) continue;
+
+      //split the keys into multiple keys separated by a ;
+      keys = keys.split(";");
+      for(let key of keys){
+        // remove the optional attribute
+        var re = /\[([a-z]*)\]/g;
+
+        var m;
+        var attr = "text";
+        //set default attribute to src if this is an image node
+        if(node.nodeName=="IMG") attr = "src";
+
+        //check if a attribute was specified in the key
+        while ((m = re.exec(key)) !== null) {
+          if (m.index === re.lastIndex) {
+            re.lastIndex++;
+          }
+          if(m){
+            key = key.replace(m[0],'');
+            attr = m[1];
+          }
+        }
+
+        if(!node._textContent) node._textContent = node.textContent;
+        if(!node._innerHTML) node._innerHTML = node.innerHTML;
+
+        //handle various attributes
+        //anything other than text,prepend,append or html will be added as an attribute on the element.
+        switch(attr){
+          case 'text':
+            node.textContent = this.tr(key);
+            break;
+          case 'prepend':
+            node.innerHTML = this.tr(key) + node._innerHTML.trim();
+            break;
+          case 'append':
+            node.innerHTML = node._innerHTML.trim() + this.tr(key);
+            break;
+          case 'html':
+            node.innerHTML = this.tr(key);
+            break;
+          default: //normal html attribute
+            node.setAttribute(attr, this.tr(key));
+            break;
+        }
+
+      }
+    }
+  }
+
 }

--- a/test/unit/fixtures/template.html
+++ b/test/unit/fixtures/template.html
@@ -1,0 +1,39 @@
+<template>
+  
+    <h1 t="title" id="test1">Title</h1>
+            
+    <p t="description" id="test2">
+      Description
+    </p>
+        
+    <p data-i18n="description" id="test-other-attr">
+      Description
+    </p>
+  
+    <p t="[text]description" id="test-text">
+      Description
+    </p>
+  
+    <p t="description2" id="test-text-with-tags">
+      Description <b>with some bold</b>
+    </p>
+  
+    <p t="[html]description2" id="test-html">
+      Description <b>with some bold</b>
+    </p>
+  
+    <p t="[prepend]description2" id="test-prepend">
+      content
+    </p>
+  
+    <p t="[append]description2" id="test-append">
+      content
+    </p>
+  
+    <p t="[html]description2;[class]description-class" id="test-multiple">
+      Description <b>with some bold</b>
+    </p>
+    
+    <img data-src="testimage-english.jpg" t="testimage" id="test-img"/>
+  
+</template>

--- a/test/unit/i18n.update-translations.spec.js
+++ b/test/unit/i18n.update-translations.spec.js
@@ -1,0 +1,140 @@
+import {I18N} from '../../src/i18n';
+import {EventAggregator} from 'aurelia-event-aggregator';
+
+describe('testing i18n translation update', () => {
+
+  let sut,loader,template,ea;
+  
+  beforeEach( (done) => {
+
+    System.config({
+      "paths": {
+        "*": "test/unit/fixtures/*.js"
+      }
+    });
+    
+    var resources = {
+      en: {
+        translation: {
+          "title": "Title",
+          "description": "Description",
+          "description2": "Description <b>with some bold</b>",
+          "description-class": "red",
+          "testimage": "testimage-english.jpg"
+        }
+      },
+      de: {
+        translation: {
+          "title": "Titel",
+          "description": "Beschreibung",
+          "description2": "Beschreibung <b>mit Fettdruck</b>",
+          "description-class": "blue",
+          "testimage": "testimage-german.jpg"
+        }
+      }
+    };
+    
+    ea = new EventAggregator();
+    sut = new I18N(ea);
+    sut.setup({
+      resStore: resources,
+      lng : 'en',
+      attributes : ['t','data-i18n'],
+      getAsync : false,
+      sendMissing : false,
+      fallbackLng : 'en',
+      debug : false
+    });
+
+    //load the the html fixture
+    System.import('template.html!text').then((result) => {
+      template = document.createElement("div");
+      template.innerHTML = result;
+      if(template.firstChild instanceof HTMLTemplateElement) template.innerHTML = template.firstChild.innerHTML;
+      document.body.appendChild(template);
+      done();
+    });
+
+    //update the translations in the template when the locale changes
+    ea.subscribe('i18n:locale:changed', payload=>{
+      sut.updateTranslations(template);
+    });
+  });
+  
+
+  it('should translate contents of elements with a translation attribute', () => {
+    expect(template.querySelector("#test1").innerHTML.trim()).toBe('Title');
+    expect(template.querySelector("#test2").innerHTML.trim()).toBe('Description');
+    sut.setLocale("de");
+    expect(template.querySelector("#test1").innerHTML.trim()).toBe('Titel');
+    expect(template.querySelector("#test2").innerHTML.trim()).toBe('Beschreibung');
+  });
+
+  it('should work with all attributes specified in the options', () => {
+    var el = template.querySelector("#test-other-attr");
+    expect(el.innerHTML.trim()).toBe('Description');
+    sut.setLocale("de");
+    expect(el.innerHTML.trim()).toBe('Beschreibung');
+  });
+
+  it('should set the textContent when using the [text] attribute', () => {
+    var el = template.querySelector("#test-text");
+    expect(el.innerHTML.trim()).toBe('Description');
+    sut.setLocale("de");
+    expect(el.innerHTML.trim()).toBe('Beschreibung');
+  });
+
+  it('should escape html tags by default or when using [text]', () => {
+    var el = template.querySelector("#test-text-with-tags");
+    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
+    sut.setLocale("de");
+    expect(el.innerHTML.trim()).toBe('Beschreibung &lt;b&gt;mit Fettdruck&lt;/b&gt;');
+  });
+
+  it('should allow tags when using the [html] attribute', () => {
+    var el = template.querySelector("#test-html");
+    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
+    sut.setLocale("de");
+    expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
+  });
+
+  it('should prepend the translation when using the [prepend] attribute, and it allows html', () => {
+    var el = template.querySelector("#test-prepend");
+    expect(el.innerHTML.trim()).toBe('content');
+    sut.setLocale("de");
+    expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>content');
+    sut.setLocale("en");
+    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>content');
+  });
+
+  it('should append the translation when using the [append] attribute, and it allows html', () => {
+    var el = template.querySelector("#test-append");
+    expect(el.innerHTML.trim()).toBe('content');
+    sut.setLocale("de");
+    expect(el.innerHTML.trim()).toBe('contentBeschreibung <b>mit Fettdruck</b>');
+    sut.setLocale("en");
+    expect(el.innerHTML.trim()).toBe('contentDescription <b>with some bold</b>');
+  });
+
+  it('should set multiple keys when separated with a semicolon', () => {
+    var el = template.querySelector("#test-multiple");
+    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
+    expect(el.className).toBe('');
+    sut.setLocale("de");
+    expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
+    expect(el.className).toBe('blue');
+    sut.setLocale("en");
+    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
+    expect(el.className).toBe('red');
+  });
+
+  it('should set the src attribute for images', () => {
+    var el = template.querySelector("#test-img");
+    expect(el.getAttribute("src")).toBeNull();
+    sut.setLocale("de");
+    expect(el.getAttribute("src")).toBe('testimage-german.jpg');
+    sut.setLocale("en");
+    expect(el.getAttribute("src")).toBe('testimage-english.jpg');
+  });
+  
+});


### PR DESCRIPTION
update the html with translated values when locale changes. can be configured with the `attributes` option

fixes: https://github.com/zewa666/aurelia-i18next/issues/11