### PR TITLE
chore(update): Update to latest releases

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 System.config({
+  "defaultJSExtensions": true,
   "transpiler": "babel",
   "babelOptions": {
     "optional": [
@@ -6,43 +7,43 @@ System.config({
     ]
   },
   "paths": {
-    "*": "*.js",
     "aurelia-i18next/*": "dist\\system/*.js",
-    "github:*": "jspm_packages/github/*.js",
-    "npm:*": "jspm_packages/npm/*.js"
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
   }
 });
 
 System.config({
   "map": {
     "Intl.js": "github:andyearnshaw/Intl.js@0.1.4",
-    "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.6.1",
-    "aurelia-loader-default": "github:aurelia/loader-default@0.7.0",
+    "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.7.0",
+    "aurelia-loader-default": "github:aurelia/loader-default@0.9.5",
     "babel": "npm:babel-core@5.4.4",
     "babel-runtime": "npm:babel-runtime@5.4.4",
-    "core-js": "npm:core-js@0.9.11",
+    "core-js": "npm:core-js@0.9.18",
     "i18next": "github:i18next/i18next@1.10.2",
     "text": "github:systemjs/plugin-text@0.0.2",
-    "github:aurelia/event-aggregator@0.6.1": {
-      "aurelia-logging": "github:aurelia/logging@0.6.0"
+    "github:aurelia/event-aggregator@0.7.0": {
+      "aurelia-logging": "github:aurelia/logging@0.6.4"
     },
-    "github:aurelia/loader-default@0.7.0": {
-      "aurelia-loader": "github:aurelia/loader@0.6.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.5.0"
+    "github:aurelia/loader-default@0.9.5": {
+      "aurelia-loader": "github:aurelia/loader@0.8.7",
+      "aurelia-metadata": "github:aurelia/metadata@0.7.3"
     },
-    "github:aurelia/loader@0.6.0": {
+    "github:aurelia/loader@0.8.7": {
       "aurelia-html-template-element": "github:aurelia/html-template-element@0.2.0",
-      "aurelia-path": "github:aurelia/path@0.6.1",
-      "core-js": "npm:core-js@0.9.11",
-      "webcomponentsjs": "github:webcomponents/webcomponentsjs@0.6.1"
+      "aurelia-metadata": "github:aurelia/metadata@0.7.3",
+      "aurelia-path": "github:aurelia/path@0.8.1",
+      "core-js": "npm:core-js@0.9.18",
+      "webcomponentsjs": "github:webcomponents/webcomponentsjs@0.6.3"
     },
-    "github:aurelia/metadata@0.5.0": {
-      "core-js": "npm:core-js@0.9.11"
+    "github:aurelia/metadata@0.7.3": {
+      "core-js": "npm:core-js@0.9.18"
     },
     "github:jspm/nodelibs-process@0.1.1": {
       "process": "npm:process@0.10.1"
     },
-    "npm:core-js@0.9.11": {
+    "npm:core-js@0.9.18": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "process": "github:jspm/nodelibs-process@0.1.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "karma-babel-preprocessor": "^5.0.1",
     "karma-chrome-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.5",
-    "karma-jspm": "^1.1.4",
+    "karma-jspm": "^2.0.1-beta.2",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",
@@ -49,7 +49,8 @@
     },
     "dependencies": {
       "Intl.js": "github:andyearnshaw/Intl.js@^0.1.4",
-      "aurelia-event-aggregator": "github:aurelia/event-aggregator@^0.6.0",
+      "aurelia-event-aggregator": "github:aurelia/event-aggregator@^0.7.0",
+      "aurelia-loader-default": "github:aurelia/loader-default@^0.9.5",
       "i18next": "github:i18next/i18next@^1.9.0"
     },
     "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,17 +8,17 @@ export {NfValueConverter} from './nf';
 export {RtValueConverter} from './rt';
 export {TValueConverter} from './t';
 
-export function configure(aurelia, cb){
+export function configure(config, cb){
   if(cb === undefined || typeof cb !== 'function') {
     throw 'You need to provide a callback method to properly configure the library';
   }
 
-  aurelia.globalizeResources('./t');
-  aurelia.globalizeResources('./nf');
-  aurelia.globalizeResources('./df');
-  aurelia.globalizeResources('./rt');
-  var instance = new I18N(aurelia.container.get(EventAggregator));
-  aurelia.container.registerInstance(I18N, instance);
+  config.globalResources('./t');
+  config.globalResources('./nf');
+  config.globalResources('./df');
+  config.globalResources('./rt');
+  var instance = new I18N(config.container.get(EventAggregator));
+  config.container.registerInstance(I18N, instance);
 
   return cb(instance);
 }

--- a/test/unit/aurelia.integration.spec.js
+++ b/test/unit/aurelia.integration.spec.js
@@ -2,8 +2,8 @@ import {configure} from '../../src/index';
 
 describe('testing aurelia configure routine', () => {
 
-  var aurelia = {
-    globalizeResources: () => {
+  var frameworkConfig = {
+    globalResources: () => {
 
     },
     container: {
@@ -26,11 +26,11 @@ describe('testing aurelia configure routine', () => {
       done();
     };
 
-    configure(aurelia, cb);
+    configure(frameworkConfig, cb);
   });
 
   it('should throw custom error message if no callback is provided', () => {
-    expect(() => { configure(aurelia); })
+  expect(() => { configure(frameworkConfig); })
       .toThrow('You need to provide a callback method to properly configure the library');
   });
 });


### PR DESCRIPTION
The aurelia plugin api has changed. These changes fixes errors when using the latest updates of Aurelia.

There are two problems when running the tests:

I got 404 errors when running the tests in `i18n.update-translations.spec.js`. Not sure how to fix this though. This is probably due to running it with jspm@beta

```
WARN [web-server]: 404: /base/test/unit/fixtures/github:systemjs/plugin-text@0.0ERROR: 'Potentially unhandled rejection [5] Error: XHR error (404 Not Found) loading http://localhost:9876/base/test/unit/fixtures/github:systemjs/plugin-text@0.0.2.js
```

And when I disable the i18n.update-translations tests, I get one error (even though it occasionally passes):

```
Chrome 44.0.2403 (Windows 10 0.0.0) nfvalueconverter tests should display number in the setup locale format by default FAILED
        Expected '123.456,789' to equal '123,456.789'.
            at Object.<anonymous> (D:/Development/aurelia-i18next/test/unit/nfvalueconverter.spec.js:25:43)
```

I'm not sure if this is due to the changes I've made, or if this problem already existed.
